### PR TITLE
Rename OrganizationSeatsChecker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OrganizationSeatsChecker
+# CheckMember
 
 This action runs on pull requests to count GitHub organization members and membership written in terraform files.
 
@@ -49,7 +49,7 @@ jobs:
 
       - name: Count seats and members
         id: seats_members
-        uses: M-Yamashita01/organization-seats-checker@v0.1
+        uses: M-Yamashita01/check-members@v0.1
         env:
           GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
           MEMBERSHIP_FILE_PATH: '${{ github.workspace }}/membership.tf' 

--- a/examples/workflows/organization_seats_checker.yml
+++ b/examples/workflows/organization_seats_checker.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Show seats
         id: seats
-        uses: M-Yamashita01/organization-seats-checker@v1
+        uses: M-Yamashita01/check-members@v1
         env:
           GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.READ_ORG_TOKEN }}
           # Set absolute file path to the terraform file containing the github_membership resources.

--- a/lib/check_members_action.rb
+++ b/lib/check_members_action.rb
@@ -6,7 +6,7 @@ require_relative 'github_organization'
 require_relative 'terraform_reader'
 require_relative 'organization_member'
 
-class OrganizationSeatsChecker
+class CheckMembersAction
   include Logging
 
   def initialize

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'organization_seats_checker'
+require_relative 'check_members_action'
 
-OrganizationSeatsChecker.new.run
+CheckMembersAction.new.run

--- a/spec/check_members_action_spec.rb
+++ b/spec/check_members_action_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe OrganizationSeatsChecker do
+RSpec.describe CheckMembersAction do
   subject { described_class.new.run }
 
   describe '#run' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,4 +6,4 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'terraform_reader'
 require 'config_validator'
 require 'github_organization'
-require 'organization_seats_checker'
+require 'check_members_action'


### PR DESCRIPTION
Because this project was renamed into CheckMembers, we renamed the part that uses that name to match accordingly.