### PR TITLE
Add mock for Kernel.exit.

### DIFF
--- a/spec/check_members_action_spec.rb
+++ b/spec/check_members_action_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe CheckMembersAction do
 
       resource = Sawyer::Resource.new(agent, hashed_response)
       allow_any_instance_of(Octokit::Client).to receive(:org).and_return(resource)
+      allow_any_instance_of(Kernel).to receive(:exit).and_return(true)
     end
 
     it 'get seats and member counts' do


### PR DESCRIPTION
In the 1c1dbe93a996747eaec121d21bdac3a48cf21249 commit, we set exit code, but we did not add mock for Kernel.exit.

As a result, when we run spec, check_members_actions_spec is executed but the spec is down.
For this reason, we add mock.