### PR TITLE
Use bundle install in script.sh instead of using setup-ruby.

### DIFF
--- a/examples/workflows/organization_seats_checker.yml
+++ b/examples/workflows/organization_seats_checker.yml
@@ -7,10 +7,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@v0.5
         with:
           ruby-version: 2.7
-          bundler-cache: true
 
       - name: Show seats
         id: seats

--- a/script.sh
+++ b/script.sh
@@ -1,1 +1,2 @@
+bundle install
 bundle exec ruby lib/index.rb


### PR DESCRIPTION
When we use this action v0.4, GitHub Actions execute this action and failed because Gemfile is not found.
We should use `bundle install` command in the script.sh, not the setup-ruby action.
Therefore we add `bundle install` command in the script.sh.