### PR TITLE
Use bundle install command in run steps and removed the command from script.sh

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,11 @@ runs:
   using: 'composite'
   steps:
     - id: member-counter
-      run: $GITHUB_ACTION_PATH/script.sh
+      run: |
+        cd $GITHUB_ACTION_PATH
+        bundle install
+        ./script.sh
+        cd $GITHUB_WORKSPACE
       shell: sh
 branding:
   icon: 'user-check'

--- a/script.sh
+++ b/script.sh
@@ -1,2 +1,1 @@
-bundle install
 bundle exec ruby lib/index.rb


### PR DESCRIPTION
When `bundle install` command was executed in the script.sh, Gemfile does not exist in the directory of the command.
Because the directory execute the command is GIHTUB_WORKSPACE, not GITHUB_ACTION_PATH.
Therefore we fix it.