### PR TITLE
Fix readme and workflow to write setup and intall

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
-          bundler-cache: true
 
       - name: Count seats and members
         id: seats_members

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Max seats an organization can use.
 Total number of membership in the `github_membership` and `github_repository_collaborator` resources written in the terraform file.
 
 ## Example usage
+Note: This action should be used with actions/setup-go action step, `Install hcl2json` step, ruby/setup-ruby action step and actions/github-script action step, such as below workflow.
+
 
 ```
 on: [pull_request]
@@ -39,6 +41,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Set up go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.17'
+
+      - name: Install hcl2json
+        run: |
+          go install github.com/tmccombs/hcl2json@latest
+
+      - name: Set up ruby
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7

--- a/script.sh
+++ b/script.sh
@@ -1,2 +1,1 @@
-brew install hcl2json
 bundle exec ruby lib/index.rb


### PR DESCRIPTION
Because this action should be used with setup-go action and install hcl2json step, we added them to README.
And we deleted unnecessary install commands in `script.sh`.