### PR TITLE
Upload coverage report by using simplecov-cobertura and codecov actions

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -37,7 +37,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           COVERAGE_SOURCE_FILE: ${{ secrets.COVERAGE_SOURCE_FILE }}
-        if: ${{ github.event_name == 'push'}}
+        if: github.event_name == 'push'
         run: |
           wget --header "Authorization: token ${GH_TOKEN}" \
           --header "Accept: application/vnd.github.v3.raw" \

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Test with RSpec
         env:
           API_KEY: ${{ secrets.CODECOV_ACCESS_TOKEN }}
+          CORRECT_COVERAGE: ${{ secrets.CORRECT_COVERAGE }}
         run: |
           bundle exec rspec
           bash <(curl -s https://codecov.io/bash) -f coverage/coverage.xml

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -37,7 +37,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           COVERAGE_SOURCE_FILE: ${{ secrets.COVERAGE_SOURCE_FILE }}
-        if: ${{ github.event_name == 'push' }}
+        # if: ${{ github.event_name == 'push' }}
         run: |
           wget --header "Authorization: token ${GH_TOKEN}" \
           --header "Accept: application/vnd.github.v3.raw" \

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Upstream to Standards
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERAGE_SOURCE_FILE: ${{ secrets.COVERAGE_SOURCE_FILE }}
         # if: ${{ github.event_name == 'push' }}
         run: |

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -33,13 +33,11 @@ jobs:
           bash <(curl -s https://codecov.io/bash) -f coverage/coverage.xml
           bundle exec ruby request.rb
 
-      - name: Upstream to Standards
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERAGE_SOURCE_FILE: ${{ secrets.COVERAGE_SOURCE_FILE }}
-        # if: ${{ github.event_name == 'push' }}
-        run: |
-          wget --header "Authorization: token ${GH_TOKEN}" \
-          --header "Accept: application/vnd.github.v3.raw" \
-          https://api.github.com/repos/codecov/standards/contents/upstream.sh
-          bash upstream.sh
+      - uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+          files: ./coverage/coverage.xml
+          flags: unittests # optional
+          name: check-members-for-codecov # optional
+          fail_ci_if_error: true # optional (default = false)
+          verbose: true # optional (default = false)

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -6,6 +6,8 @@ jobs:
     name: Run spec
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
 
       - name: Set up go
         uses: actions/setup-go@v2
@@ -28,7 +30,7 @@ jobs:
         run: |
           bundle exec rspec
           bash <(curl -s https://codecov.io/bash) -f coverage/coverage.xml
-          ruby request.rb
+          bundle exec ruby request.rb
 
       - name: Upstream to Standards
         env:

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -23,5 +23,20 @@ jobs:
           bundler-cache: true
 
       - name: Test with RSpec
+        env:
+          API_KEY: ${{ secrets.CODECOV_ACCESS_TOKEN }}
         run: |
           bundle exec rspec
+          bash <(curl -s https://codecov.io/bash) -f coverage/coverage.xml
+          ruby request.rb
+
+      - name: Upstream to Standards
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          COVERAGE_SOURCE_FILE: ${{ secrets.COVERAGE_SOURCE_FILE }}
+        if: ${{ github.event_name == 'push'}}
+        run: |
+          wget --header "Authorization: token ${GH_TOKEN}" \
+          --header "Accept: application/vnd.github.v3.raw" \
+          https://api.github.com/repos/codecov/standards/contents/upstream.sh
+          bash upstream.sh

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -33,7 +33,8 @@ jobs:
           bash <(curl -s https://codecov.io/bash) -f coverage/coverage.xml
           bundle exec ruby request.rb
 
-      - uses: codecov/codecov-action@v2
+      - name: Upload coverage reports
+        uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
           files: ./coverage/coverage.xml

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -37,7 +37,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           COVERAGE_SOURCE_FILE: ${{ secrets.COVERAGE_SOURCE_FILE }}
-        if: github.event_name == 'push'
+        if: ${{ github.event_name == 'push' }}
         run: |
           wget --header "Authorization: token ${GH_TOKEN}" \
           --header "Accept: application/vnd.github.v3.raw" \

--- a/Gemfile
+++ b/Gemfile
@@ -17,4 +17,8 @@ group :development, :test do
 
   # Simplecov-cobertura to generate an xml coverage file which can then be uploaded to Codecov
   gem 'simplecov-cobertura'
+
+  # For API calls 
+  gem 'json'
+  gem 'rest-client'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -12,9 +12,9 @@ group :development, :test do
   gem 'rubocop-rspec', require: false
   gem 'sawyer'
 
-  #Simplecov to generate coverage info
+  # Simplecov to generate coverage info
   gem 'simplecov', require: false
 
-  #Simplecov-cobertura to generate an xml coverage file which can then be uploaded to Codecov 
+  # Simplecov-cobertura to generate an xml coverage file which can then be uploaded to Codecov
   gem 'simplecov-cobertura'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,10 @@ group :development, :test do
   gem 'rubocop', require: false
   gem 'rubocop-rspec', require: false
   gem 'sawyer'
-end
 
-group :test do
-  gem 'codecov', require: false
+  #Simplecov to generate coverage info
+  gem 'simplecov', require: false
+
+  #Simplecov-cobertura to generate an xml coverage file which can then be uploaded to Codecov 
+  gem 'simplecov-cobertura'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ group :development, :test do
   # Simplecov-cobertura to generate an xml coverage file which can then be uploaded to Codecov
   gem 'simplecov-cobertura'
 
-  # For API calls 
+  # For API calls
   gem 'json'
   gem 'rest-client'
 end

--- a/request.rb
+++ b/request.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Function: this is a simple ruby script that calls Codecov's API to make sure it's returning the proper coverage
 
 require 'rest-client'
@@ -29,9 +30,6 @@ def ping_api
   # get the commit data and coverage percentage
   commit_data = to_json['commits'][0]
   coverage_percentage = commit_data['totals']['c']
-
-  puts "ENV['CORRECT_COVERAGE']: #{ENV['CORRECT_COVERAGE']}"
-  puts "coverage_percentage: #{coverage_percentage}"
 
   # Coverage percentage should be 93.65079 (this is specfied via environment variables on Travis), fail build otherwise
   if coverage_percentage.to_i >= ENV['CORRECT_COVERAGE'].to_i

--- a/request.rb
+++ b/request.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+# Function: this is a simple ruby script that calls Codecov's API to make sure it's returning the proper coverage
+
+require 'rest-client'
+require 'json'
+
+puts "Codecov API Validation\n"
+
+def run!
+  nap
+  ping_api
+end
+
+# nap time
+def nap
+  puts "Waiting 60 seconds for report to upload before pinging API...\n"
+  sleep(60)
+end
+
+def ping_api
+  puts "Pinging Codecov's API..\n"
+
+  # REST call
+  response_data = RestClient.get('https://codecov.io/api/gh/M-Yamashita01/check-members', params: { token: ENV['API_KEY'] })
+
+  # Parse request data to JSON format
+  to_json = JSON.parse(response_data)
+
+  # get the commit data and coverage percentage
+  commit_data = to_json['commits'][0]
+  coverage_percentage = commit_data['totals']['c']
+
+  # Coverage percentage should be 93.65079 (this is specfied via environment variables on Travis), fail build otherwise
+  # if coverage_percentage == ENV['CORRECT_COVERAGE']
+      # puts "Success! Codecov's API returned the correct coverage percentage, "+ ENV['CORRECT_COVERAGE']
+      # exit 0
+  # else
+      # puts "Whoops, something is wrong D: Codecov did not return the correct coverage percentage. Coverage percentage should be "+ ENV['CORRECT_COVERAGE'] +" but Codecov returned "+coverage_percentage
+      # exit 1
+  # end
+  exit 0
+end
+
+run!

--- a/request.rb
+++ b/request.rb
@@ -31,14 +31,13 @@ def ping_api
   coverage_percentage = commit_data['totals']['c']
 
   # Coverage percentage should be 93.65079 (this is specfied via environment variables on Travis), fail build otherwise
-  # if coverage_percentage == ENV['CORRECT_COVERAGE']
-      # puts "Success! Codecov's API returned the correct coverage percentage, "+ ENV['CORRECT_COVERAGE']
-      # exit 0
-  # else
-      # puts "Whoops, something is wrong D: Codecov did not return the correct coverage percentage. Coverage percentage should be "+ ENV['CORRECT_COVERAGE'] +" but Codecov returned "+coverage_percentage
-      # exit 1
-  # end
-  exit 0
+  if coverage_percentage >= ENV['CORRECT_COVERAGE']
+    puts "Success! Codecov's API returned the correct coverage percentage, #{ENV['CORRECT_COVERAGE']}"
+    exit 0
+  else
+    puts "Whoops, something is wrong D: Codecov did not return the correct coverage percentage. Coverage percentage should be #{ENV['CORRECT_COVERAGE']} but Codecov returned #{coverage_percentage}"
+    exit 1
+  end
 end
 
 run!

--- a/request.rb
+++ b/request.rb
@@ -30,8 +30,11 @@ def ping_api
   commit_data = to_json['commits'][0]
   coverage_percentage = commit_data['totals']['c']
 
+  puts "ENV['CORRECT_COVERAGE']: #{ENV['CORRECT_COVERAGE']}"
+  puts "coverage_percentage: #{coverage_percentage}"
+
   # Coverage percentage should be 93.65079 (this is specfied via environment variables on Travis), fail build otherwise
-  if coverage_percentage >= ENV['CORRECT_COVERAGE']
+  if coverage_percentage.to_i >= ENV['CORRECT_COVERAGE'].to_i
     puts "Success! Codecov's API returned the correct coverage percentage, #{ENV['CORRECT_COVERAGE']}"
     exit 0
   else

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,5 @@ require 'terraform_reader'
 require 'simplecov'
 SimpleCov.start
 
-if ENV['CI'] == 'true'
-  require 'simplecov-cobertura'
-  SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
-end
+require 'simplecov-cobertura'
+SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,6 @@ require 'simplecov'
 SimpleCov.start
 
 if ENV['CI'] == 'true'
-  require 'codecov'
-  SimpleCov.formatter = SimpleCov::Formatter::Codecov
+  require 'simplecov-cobertura'
+  SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
 end


### PR DESCRIPTION
Codecov uploader is being deprecated, and codecov team recommended migrating to new uploader.
So that, we use simplecov-cobertura.