### PR TITLE
Change code position for coverage measurement.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+require 'simplecov'
+SimpleCov.start
+
+require 'simplecov-cobertura'
+SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
+
 require 'rspec'
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
@@ -9,9 +15,3 @@ require 'config_validator'
 require 'github_api_request'
 require 'hcl2hash_conversion'
 require 'terraform_reader'
-
-require 'simplecov'
-SimpleCov.start
-
-require 'simplecov-cobertura'
-SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter


### PR DESCRIPTION
simplecov code should be placed at the top in spec_helper to measure coverage correctly.
ref: https://stackoverflow.com/questions/35476814/simplecov-calculate-0-coverage-for-user-model