### PR TITLE
Use brew command in GitHub Actions workflow.

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -9,14 +9,9 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Set up go
-        uses: actions/setup-go@v2
-        with:
-          go-version: '1.17'
-
       - name: Install hcl2json
-        run: |
-          go install github.com/tmccombs/hcl2json@latest
+        run: brew install hcl2json
+          
 
       - name: Set up ruby
         uses: ruby/setup-ruby@v1
@@ -25,8 +20,7 @@ jobs:
           bundler-cache: true
 
       - name: Test with RSpec
-        run: |
-          bundle exec rspec
+        run: bundle exec rspec
 
       - name: Upload coverage reports
         uses: codecov/codecov-action@v2

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
-gem "octokit", "~> 4.0"
+gem 'octokit', '~> 4.0'
 
 group :development, :test do
   gem 'rspec'

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
-gem 'octokit'
+gem "octokit", "~> 4.0"
 
 group :development, :test do
   gem 'rspec'

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Max seats an organization can use.
 Total number of membership in the `github_membership` and `github_repository_collaborator` resources written in the terraform file.
 
 ## Example usage
-Note: This action should be used with actions/setup-go action step, `Install hcl2json` step, ruby/setup-ruby action step and actions/github-script action step, such as below workflow.
+Note: This action should be used with `Install hcl2json` step, ruby/setup-ruby action step and actions/github-script action step, such as below workflow.
 
 
 ```
@@ -41,14 +41,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up go
-        uses: actions/setup-go@v2
-        with:
-          go-version: '1.17'
-
       - name: Install hcl2json
-        run: |
-          go install github.com/tmccombs/hcl2json@latest
+        run: brew install hcl2json
 
       - name: Set up ruby
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Because we can use brew command on ubuntu latest(20.04) environments in workflow, we use brew command instead of setup-go step and go install step.