### PR TITLE
Enabled checking member existence.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,20 +65,22 @@ jobs:
         with:
           script: |
             var output = `Current seats in organization and members in terraform files.\n
-              ・Seats that membership used:: ${{steps.seats_members.outputs.filled_seats}}\n
-              ・Max seats an organization can use: ${{steps.seats_members.outputs.max_seats}}\n
-              ・Total number of membership in terraform files: ${{steps.seats_members.outputs.members_in_terraform}}\n\n
+              ・Seats that membership used:: ${{ steps.seats_members.outputs.filled_seats }}\n
+              ・Max seats an organization can use: ${{ steps.seats_members.outputs.max_seats }}\n
+              ・Total number of membership in terraform files: ${{ steps.seats_members.outputs.members_in_terraform }}\n\n
             `
-            const numberOfSeatsInShortage = ${{steps.seats_members.outputs.members_in_terraform}} - ${{steps.seats_members.outputs.max_seats}}
+            const numberOfSeatsInShortage = ${{ steps.seats_members.outputs.members_in_terraform }} - ${{ steps.seats_members.outputs.max_seats }}
             var additional_message = `There is no shortage of seats.\n`
             if (numberOfSeatsInShortage > 0) {
               additional_message = `There are ${numberOfSeatsInShortage} seats missing. Please add seats.\n`
             }
 
-            const non_existing_members = ${{steps.seats_members.outputs.non_existing_members}}
             var notify_non_existing_member_message = ``
+            const non_existing_members = "${{ steps.seats_members.outputs.non_existing_members }}"
             if (non_existing_members.length > 0) {
-              notify_non_existing_member_message = `Some members in terraform files do not exist. Non-existing members: ${non_existing_members} .\n`
+              notify_non_existing_member_message = `Some members in terraform files do not exist. Please check the members.\n
+              ・Non-existing members: ${non_existing_members}.\n\n
+              `
             }
 
             output += additional_message

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ jobs:
               additional_message = `There are ${numberOfSeatsInShortage} seats missing. Please add seats.\n`
             }
 
-            notify_non_existing_member_message = ``
-            non_existing_members = ${{steps.seats_members.outputs.non_existing_members}}
+            const non_existing_members = ${{steps.seats_members.outputs.non_existing_members}}
+            var notify_non_existing_member_message = ``
             if (non_existing_members.length > 0) {
               notify_non_existing_member_message = `Some members in terraform files do not exist. Non-existing members: ${non_existing_members} .\n`
             }

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Max seats an organization can use.
 ### `members_in_terraform`
 Total number of membership in the `github_membership` and `github_repository_collaborator` resources written in the terraform file.
 
+### `non_existing_members`
+Members which are in terraform do not exist in GitHub.
+
 ## Example usage
 Note: This action should be used with `Install hcl2json` step, ruby/setup-ruby action step and actions/github-script action step, such as below workflow.
 
@@ -71,7 +74,15 @@ jobs:
             if (numberOfSeatsInShortage > 0) {
               additional_message = `There are ${numberOfSeatsInShortage} seats missing. Please add seats.\n`
             }
+
+            notify_non_existing_member_message = ``
+            non_existing_members = ${{steps.seats_members.outputs.non_existing_members}}
+            if (non_existing_members.length > 0) {
+              notify_non_existing_member_message = `Some members in terraform files do not exist. Non-existing members: ${non_existing_members} .\n`
+            }
+
             output += additional_message
+            output += notify_non_existing_member_message
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,9 @@ outputs:
   members_in_terraform:
     description: 'Total number of membership in the `github_membership` and `github_repository_collaborator` resources written in the terraform file.'
     value: ${{ steps.member-counter.outputs.members_in_terraform }}
+  non_existing_members:
+    description: 'Members which are in terraform do not exist in GitHub.'
+    value: ${{ steps.member-counter.outputs.non_existing_members }}
 runs:
   using: 'composite'
   steps:

--- a/lib/check_members_action.rb
+++ b/lib/check_members_action.rb
@@ -36,7 +36,7 @@ class CheckMembersAction
 
     if @verify_account == 'true'
       non_existing_usernames = get_non_existing_usernames
-      usernames = non_existing_usernames.join(',')
+      usernames = non_existing_usernames.join(', ')
       if !non_existing_usernames.empty?
         logger.error('Some users in terraform files do not exist.')
         logger.error("Non existing users: #{usernames}")

--- a/lib/check_members_action.rb
+++ b/lib/check_members_action.rb
@@ -35,9 +35,8 @@ class CheckMembersAction
     members_in_terraform = usernames_in_terraform.size
 
     if @verify_account == 'true'
-      non_existing_usernames = get_non_existing_usernames
       usernames = non_existing_usernames.join(', ')
-      if !non_existing_usernames.empty?
+      if !usernames.empty?
         logger.error('Some users in terraform files do not exist.')
         logger.error("Non existing users: #{usernames}")
       end
@@ -71,7 +70,7 @@ class CheckMembersAction
     @github_api_request ||= GithubApiRequest.new(access_token: @access_token)
   end
 
-  def get_non_existing_usernames
+  def non_existing_usernames
     usernames_in_terraform.reject do |username|
       exist_github_user?(username: username)
     end

--- a/lib/check_members_action.rb
+++ b/lib/check_members_action.rb
@@ -35,11 +35,12 @@ class CheckMembersAction
     members_in_terraform = usernames_in_terraform.size
 
     if @verify_account == 'true'
-      usernames = no_exist_usernames
+      usernames = non_existing_usernames
       if !usernames.empty?
+        joined_usernames = usernames.join(',')
         logger.error('Some users in terraform files do not exist.')
-        logger.error("No exist users: #{usernames.join(',')}")
-        exit(false)
+        logger.error("Non existing users: #{joined_usernames}")
+        puts "::set-output name=non_existing_members::#{joined_usernames}"
       end
     end
 
@@ -70,7 +71,7 @@ class CheckMembersAction
     @github_api_request ||= GithubApiRequest.new(access_token: @access_token)
   end
 
-  def no_exist_usernames
+  def non_existing_usernames
     usernames_in_terraform.reject do |username|
       exist_github_user?(username: username)
     end

--- a/lib/check_members_action.rb
+++ b/lib/check_members_action.rb
@@ -35,13 +35,13 @@ class CheckMembersAction
     members_in_terraform = usernames_in_terraform.size
 
     if @verify_account == 'true'
-      usernames = non_existing_usernames
-      if !usernames.empty?
-        joined_usernames = usernames.join(',')
+      non_existing_usernames = get_non_existing_usernames
+      usernames = non_existing_usernames.join(',')
+      if !non_existing_usernames.empty?
         logger.error('Some users in terraform files do not exist.')
-        logger.error("Non existing users: #{joined_usernames}")
-        puts "::set-output name=non_existing_members::#{joined_usernames}"
+        logger.error("Non existing users: #{usernames}")
       end
+      puts "::set-output name=non_existing_members::#{usernames}"
     end
 
     puts "::set-output name=filled_seats::#{filled_seats}"
@@ -71,7 +71,7 @@ class CheckMembersAction
     @github_api_request ||= GithubApiRequest.new(access_token: @access_token)
   end
 
-  def non_existing_usernames
+  def get_non_existing_usernames
     usernames_in_terraform.reject do |username|
       exist_github_user?(username: username)
     end

--- a/lib/github_api_request.rb
+++ b/lib/github_api_request.rb
@@ -28,6 +28,9 @@ class GithubApiRequest
 
   def exist_user?(username:)
     @client.user(username)
-    @client.last_response.status.eql?(200)
+  rescue StandardError => e
+    logger.error(e.message)
+    logger.error(e.backtrace.join("\n"))
+    false
   end
 end

--- a/spec/github_api_request_spec.rb
+++ b/spec/github_api_request_spec.rb
@@ -84,8 +84,9 @@ RSpec.describe GithubApiRequest do
     end
 
     context 'when get a not existed user' do
-      let(:status_code) { 404 }
-      let(:body) { '' }
+      before do
+        allow_any_instance_of(Octokit::Client).to receive(:user).and_raise(StandardError)
+      end
 
       it { expect(subject).to be_falsey }
     end


### PR DESCRIPTION
When we used this action in Pull Requests, the action ignored members which are written in terraform files but do not exist in GitHub.
So, when Pull Request is merged, `terraform apply` is failed and we need a long time to investigate the cause of failure.
To resolve the problem, we enabled checking member existence.
