### PR TITLE
Replace set-output with GITHUB_OUTPUT

### DIFF
--- a/lib/check_members_action.rb
+++ b/lib/check_members_action.rb
@@ -34,18 +34,21 @@ class CheckMembersAction
 
     members_in_terraform = usernames_in_terraform.size
 
+    github_output = []
     if @verify_account == 'true'
       usernames = non_existing_usernames.join(', ')
       if !usernames.empty?
         logger.error('Some users in terraform files do not exist.')
         logger.error("Non existing users: #{usernames}")
       end
-      puts "::set-output name=non_existing_members::#{usernames}"
+
+      github_output << "non_existing_members=#{usernames}"
     end
 
-    puts "::set-output name=filled_seats::#{filled_seats}"
-    puts "::set-output name=max_seats::#{max_seats}"
-    puts "::set-output name=members_in_terraform::#{members_in_terraform}"
+    github_output << "filled_seats=#{filled_seats}"
+    github_output << "max_seats=#{max_seats}"
+    github_output << "members_in_terraform=#{members_in_terraform}"
+    ENV['GITHUB_OUTPUT'] = github_output.join('\n')
 
     exit
   rescue StandardError => e

--- a/lib/check_members_action.rb
+++ b/lib/check_members_action.rb
@@ -48,7 +48,7 @@ class CheckMembersAction
     github_output << "filled_seats=#{filled_seats}"
     github_output << "max_seats=#{max_seats}"
     github_output << "members_in_terraform=#{members_in_terraform}"
-    ENV['GITHUB_OUTPUT'] = github_output.join('\n')
+    system("echo \"#{github_output.join('\n')}\" >> \"$GITHUB_OUTPUT\"")
 
     exit
   rescue StandardError => e


### PR DESCRIPTION
The `set-output` is deprecated because GitHub published the information  https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ .
Therefore, we replaced `set-output` with `GITHUB_OUTPUT`.